### PR TITLE
feat: Phare status-page integration

### DIFF
--- a/alembic/versions/3f8c2a1b9d04_create_phareincidents.py
+++ b/alembic/versions/3f8c2a1b9d04_create_phareincidents.py
@@ -1,0 +1,44 @@
+"""create phareincidents
+
+Revision ID: 3f8c2a1b9d04
+Revises: 65d4a71a8e37
+Create Date: 2026-03-09 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision = "3f8c2a1b9d04"
+down_revision = "65d4a71a8e37"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "phareincidentrecord",
+        sa.Column("channel_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("message_ts", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("parent", sa.Integer(), nullable=False),
+        sa.Column("state", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("updates", sa.JSON(), nullable=True),
+        sa.Column("upstream_id", sa.Integer(), nullable=False),
+        sa.Column("url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["parent"],
+            ["incidentrecord.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("phareincidentrecord")

--- a/incidentbot/api/routes/incident.py
+++ b/incidentbot/api/routes/incident.py
@@ -19,6 +19,7 @@ from incidentbot.models.database import (
     JiraIssueRecord,
     GitlabIssueRecord,
     PagerDutyIncidentRecord,
+    PhareIncidentRecord,
     PostmortemRecord,
     StatuspageIncidentRecord,
 )
@@ -160,6 +161,32 @@ async def get_incident_postmortems(
         records = session.exec(
             select(PostmortemRecord).filter(
                 PostmortemRecord.parent == incident.id
+            )
+        ).all()
+
+        return records
+    except NoResultFound:
+        raise HTTPException(status_code=404, detail="incident not found")
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.get(
+    "/incident/{slug}/phare",
+    dependencies=[Depends(get_current_active_superuser)],
+    status_code=status.HTTP_200_OK,
+)
+async def get_incident_phare(
+    session: SessionDep, slug: str
+) -> list[PhareIncidentRecord]:
+    try:
+        incident = session.exec(
+            select(IncidentRecord).filter(IncidentRecord.slug == slug)
+        ).one()
+
+        records = session.exec(
+            select(PhareIncidentRecord).filter(
+                PhareIncidentRecord.parent == incident.id
             )
         ).all()
 

--- a/incidentbot/configuration/settings.py
+++ b/incidentbot/configuration/settings.py
@@ -200,6 +200,24 @@ class AtlassianIntegration(BaseModel):
     statuspage: StatuspageIntegration | None = None
 
 
+class PhareIntegrationPermissions(BaseModel):
+    """
+    Model for Phare permissions
+    """
+
+    groups: list[str] | None = None
+
+
+class PhareIntegration(BaseModel):
+    """
+    Model for the phare field
+    """
+
+    enabled: bool = False
+    permissions: PhareIntegrationPermissions | None = None
+    url: str = "https://phare.io"
+
+
 class PagerDutyIntegration(BaseModel):
     """
     Model for the pagerduty field
@@ -224,6 +242,7 @@ class Integrations(BaseModel):
 
     atlassian: AtlassianIntegration | None = None
     pagerduty: PagerDutyIntegration | None = None
+    phare: PhareIntegration | None = None
     zoom: ZoomIntegration | None = None
     gitlab: GitlabIntegration | None = None
 
@@ -391,6 +410,9 @@ class Settings(BaseSettings):
     SLACK_BOT_TOKEN: str | None = None
     SLACK_USER_TOKEN: str | None = None
 
+    PHARE_API_KEY: str | None = None
+    PHARE_PROJECT_ID: int | None = None
+
     STATUSPAGE_API_KEY: str | None = None
     STATUSPAGE_PAGE_ID: str | None = None
 
@@ -543,6 +565,15 @@ class Settings(BaseSettings):
                 )
                 self._check_required_integration_var(
                     "GITLAB_API_TOKEN", self.GITLAB_API_TOKEN, "Gitlab"
+                )
+
+            if (
+                self.integrations
+                and self.integrations.phare
+                and self.integrations.phare.enabled
+            ):
+                self._check_required_integration_var(
+                    "PHARE_API_KEY", self.PHARE_API_KEY, "Phare"
                 )
 
         return self

--- a/incidentbot/configuration/settings.py
+++ b/incidentbot/configuration/settings.py
@@ -215,7 +215,6 @@ class PhareIntegration(BaseModel):
 
     enabled: bool = False
     permissions: PhareIntegrationPermissions | None = None
-    url: str = "https://phare.io"
 
 
 class PagerDutyIntegration(BaseModel):

--- a/incidentbot/incident/core.py
+++ b/incidentbot/incident/core.py
@@ -16,6 +16,7 @@ from incidentbot.slack.messages import (
     BlockBuilder,
     IncidentChannelDigestNotification,
 )
+from incidentbot.phare.slack import return_new_phare_incident_message
 from incidentbot.statuspage.slack import return_new_statuspage_incident_message
 from incidentbot.zoom.meeting import ZoomMeeting
 from pydantic import BaseModel
@@ -524,6 +525,33 @@ class Incident:
                 except slack_sdk.errors.SlackApiError as error:
                     logger.error(
                         f"Error sending Statuspage prompt to incident channel {record.channel_name}: {error}"
+                    )
+
+            """
+            Post prompt for creating Phare incident if enabled (optional)
+            """
+
+            if (
+                settings.integrations
+                and settings.integrations.phare
+                and settings.integrations.phare.enabled
+            ):
+                phare_starter_message_content = return_new_phare_incident_message(
+                    channel_id=record.channel_id
+                )
+
+                logger.info(
+                    f"Sending Phare prompt to {record.channel_name}"
+                )
+
+                try:
+                    slack_web_client.chat_postMessage(
+                        **phare_starter_message_content,
+                        text="Phare prompt has been posted to an incident.",
+                    )
+                except slack_sdk.errors.SlackApiError as error:
+                    logger.error(
+                        f"Error sending Phare prompt to incident channel {record.channel_name}: {error}"
                     )
 
             """

--- a/incidentbot/models/database.py
+++ b/incidentbot/models/database.py
@@ -428,6 +428,33 @@ class StatuspageIncidentRecord(SQLModel, table=True):
     upstream_id: str
 
 
+class PhareIncidentRecord(SQLModel, table=True):
+    channel_id: str | None = None
+    id: uuid.UUID = Field(primary_key=True, default_factory=uuid.uuid4)
+    message_ts: str | None = None
+    name: str | None = None
+    parent: Annotated[
+        int,
+        Field(
+            foreign_key="incidentrecord.id",
+            ondelete="CASCADE",
+            exclude=True,
+        ),
+    ]
+    state: str | None = None
+    updated_at: Optional[datetime] = Field(
+        sa_column=Column(
+            DateTime(),
+            onupdate=func.now(),
+        )
+    )
+    updates: list | None = Field(
+        sa_column=Column(MutableList.as_mutable(JSON)), default_factory=list
+    )
+    upstream_id: int
+    url: str | None = None
+
+
 class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str

--- a/incidentbot/models/incident.py
+++ b/incidentbot/models/incident.py
@@ -5,6 +5,7 @@ from incidentbot.models.database import (
     IncidentParticipant,
     IncidentRecord,
     PagerDutyIncidentRecord,
+    PhareIncidentRecord,
     PostmortemRecord,
     StatuspageIncidentRecord,
     GitlabIssueRecord,
@@ -92,6 +93,30 @@ class IncidentDatabaseInterface:
                 ).one()
         except NoResultFound:
             logger.error(f"Statuspage incident not found for incident {id}")
+        except Exception as error:
+            logger.error(f"Lookup failed: {error}")
+
+    @classmethod
+    def get_phare_incident_record(
+        self,
+        id: int = None,
+    ) -> PhareIncidentRecord:
+        """
+        Read a single Phare incident record from the database
+
+        Parameters:
+            id (int): Filter by incident id
+        """
+
+        try:
+            with Session(engine) as session:
+                return session.exec(
+                    select(PhareIncidentRecord).filter(
+                        PhareIncidentRecord.parent == id,
+                    )
+                ).one()
+        except NoResultFound:
+            logger.error(f"Phare incident not found for incident {id}")
         except Exception as error:
             logger.error(f"Lookup failed: {error}")
 

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -1,0 +1,320 @@
+import requests
+
+from datetime import datetime, timezone
+from incidentbot.configuration.settings import settings
+from incidentbot.logging import logger
+from incidentbot.models.database import engine, PhareIncidentRecord
+from incidentbot.models.incident import IncidentDatabaseInterface
+from incidentbot.slack.client import slack_web_client
+from sqlmodel import Session, select
+from typing import Any
+
+api = "https://api.phare.io"
+
+
+def _headers() -> dict:
+    h = {"Authorization": f"Bearer {settings.PHARE_API_KEY}"}
+    if settings.PHARE_PROJECT_ID:
+        h["X-Phare-Project-Id"] = str(settings.PHARE_PROJECT_ID)
+    return h
+
+
+class PhareMonitors:
+    """
+    Fetches and exposes Phare monitors from the API
+    """
+
+    def __init__(self):
+        self._monitors = []
+        page = 1
+        while True:
+            resp = requests.get(
+                f"{api}/uptime/monitors",
+                headers=_headers(),
+                params={"page": page, "per_page": 100},
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            self._monitors.extend(body.get("data", []))
+            links = body.get("links", {})
+            if not links.get("next"):
+                break
+            page += 1
+
+    @property
+    def list_of_names(self) -> list[str]:
+        return [m["name"] for m in self._monitors]
+
+    @property
+    def list_of_dict_name_ids(self) -> list[dict[str, int]]:
+        return [{m["name"]: m["id"]} for m in self._monitors]
+
+
+class PhareIncident:
+    """
+    Instantiates a Phare incident
+    """
+
+    def __init__(self, request_data: dict):
+        self.request_data = request_data
+        self.payload = {
+            "title": self.request_data["title"],
+            "description": self.request_data.get("description", ""),
+            "impact": self.request_data.get("impact", "operational"),
+            "monitor_ids": self.request_data.get("monitor_ids", []),
+        }
+
+    def start(self) -> str | None:
+        """
+        Create the Phare incident and store a record in the DB
+        """
+
+        channel_id = self.request_data["channel_id"]
+
+        # Find the ts of the Phare prompt message
+        message_ts = None
+        result = slack_web_client.conversations_history(
+            channel=channel_id,
+            inclusive=True,
+        )
+        for message in result.get("messages", []):
+            if message.get("text") == "Phare prompt has been posted to an incident.":
+                message_ts = message.get("ts")
+
+        try:
+            resp = requests.post(
+                f"{api}/uptime/incidents",
+                headers=_headers(),
+                json=self.payload,
+            )
+            resp.raise_for_status()
+            self.info = resp.json()
+            logger.info(f"Created Phare incident: {self.info.get('title')}")
+
+            incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+        except Exception as error:
+            logger.error(f"Error during Phare incident creation: {error}")
+            return None
+
+        try:
+            record = PhareIncidentRecord(
+                channel_id=channel_id,
+                message_ts=message_ts,
+                name=self.info.get("title"),
+                parent=incident_data.id,
+                state=self.info.get("state", "investigating"),
+                updated_at=datetime.now(tz=timezone.utc),
+                updates=[],
+                upstream_id=self.info.get("id"),
+                url=self.info.get("url"),
+            )
+
+            with Session(engine) as session:
+                session.add(record)
+                session.commit()
+
+            return message_ts
+        except Exception as error:
+            logger.error(f"Error during Phare incident record creation: {error}")
+            return None
+
+    @property
+    def details(self) -> dict:
+        return self.info
+
+
+class PhareIncidentUpdate:
+    """
+    Updates a Phare incident
+    """
+
+    @staticmethod
+    def update(channel_id: str, content: str, state: str):
+        """
+        Update or recover a Phare incident
+        """
+
+        incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+
+        with Session(engine) as session:
+            record = session.exec(
+                select(PhareIncidentRecord).filter(
+                    PhareIncidentRecord.parent == incident_data.id
+                )
+            ).one()
+
+            try:
+                if state == "resolved":
+                    resp = requests.post(
+                        f"{api}/uptime/incidents/{record.upstream_id}/recover",
+                        headers=_headers(),
+                    )
+                    resp.raise_for_status()
+                else:
+                    resp = requests.post(
+                        f"{api}/uptime/incidents/{record.upstream_id}/updates",
+                        headers=_headers(),
+                        json={"state": state, "content": content},
+                    )
+                    resp.raise_for_status()
+                    update_data = resp.json()
+                    updates = list(record.updates or [])
+                    updates.append(
+                        {
+                            "content": content,
+                            "state": state,
+                            "time": datetime.now(tz=timezone.utc).isoformat(),
+                        }
+                    )
+                    record.updates = updates
+            except Exception as error:
+                logger.error(f"Error updating Phare incident: {error}")
+                return
+
+            record.state = state
+            record.updated_at = datetime.now(tz=timezone.utc)
+
+            session.add(record)
+            session.commit()
+
+            try:
+                slack_web_client.chat_update(
+                    channel=incident_data.channel_id,
+                    ts=record.message_ts,
+                    text=f"Phare incident updated to {state}.",
+                    blocks=PhareIncidentUpdate.update_management_message(
+                        incident_data.channel_id
+                    ),
+                )
+            except Exception as error:
+                logger.error(
+                    f"Error updating Phare message for {incident_data.channel_name}: {error}"
+                )
+
+    @staticmethod
+    def update_management_message(channel_id: str) -> list[dict[str, Any]]:
+        """
+        Formats the Phare management message for updates
+        """
+
+        incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+
+        with Session(engine) as session:
+            record = session.exec(
+                select(PhareIncidentRecord).filter(
+                    PhareIncidentRecord.parent == incident_data.id
+                )
+            ).one()
+
+            blocks = [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Phare* - A Phare incident has been created. Use the options here to manage it.",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Name*: {}\n*State*: {}\n".format(
+                            record.name,
+                            record.state.title() if record.state else "",
+                        ),
+                    },
+                },
+                {"type": "divider"},
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ":loudspeaker: Updates",
+                    },
+                },
+            ]
+
+            for update in record.updates or []:
+                blocks.extend(
+                    [
+                        {
+                            "type": "section",
+                            "fields": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": "*Message:* {}".format(
+                                        update.get("content")
+                                    ),
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": "*State:* {}".format(
+                                        update.get("state", "").title()
+                                    ),
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": "*Time:* {}".format(
+                                        update.get("time")
+                                    ),
+                                },
+                            ],
+                        },
+                        {"type": "divider"},
+                    ]
+                )
+
+            action_elements = [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Update Incident",
+                        "emoji": True,
+                    },
+                    "value": channel_id,
+                    "action_id": "phare_incident_update_modal",
+                    "style": "primary",
+                },
+            ]
+
+            if record.url:
+                action_elements.append(
+                    {
+                        "type": "button",
+                        "style": "primary",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "View Incident",
+                        },
+                        "action_id": "phare.view_incident",
+                        "url": record.url,
+                    }
+                )
+
+            action_elements.append(
+                {
+                    "type": "button",
+                    "style": "primary",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Open Phare",
+                    },
+                    "action_id": "phare.open",
+                    "url": settings.integrations.phare.url,
+                }
+            )
+
+            blocks.extend(
+                [
+                    {
+                        "type": "actions",
+                        "block_id": "phare_update_button",
+                        "elements": action_elements,
+                    },
+                    {"type": "divider"},
+                ]
+            )
+
+            return blocks

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -181,7 +181,7 @@ class PhareIncidentUpdate:
                 slack_web_client.chat_update(
                     channel=incident_data.channel_id,
                     ts=record.message_ts,
-                    text=f"Phare incident updated to {state}.",
+                    text=f"Phare Uptime incident updated to {state}.",
                     blocks=PhareIncidentUpdate.update_management_message(
                         incident_data.channel_id
                     ),
@@ -212,7 +212,7 @@ class PhareIncidentUpdate:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "*Phare* - A Phare incident has been created. Use the options here to manage it.",
+                        "text": "*Phare Uptime* - A Phare Uptime incident has been created. Use the options here to manage it.",
                     },
                 },
                 {
@@ -299,7 +299,7 @@ class PhareIncidentUpdate:
                     "style": "primary",
                     "text": {
                         "type": "plain_text",
-                        "text": "Open Phare",
+                        "text": "Open Phare Uptime",
                     },
                     "action_id": "phare.open",
                     "url": phare_url,

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -2,8 +2,6 @@ import requests
 
 from datetime import datetime, timezone
 from incidentbot.configuration.settings import settings
-
-phare_url = "https://app.phare.io"
 from incidentbot.logging import logger
 from incidentbot.models.database import engine, PhareIncidentRecord
 from incidentbot.models.incident import IncidentDatabaseInterface
@@ -12,6 +10,7 @@ from sqlmodel import Session, select
 from typing import Any
 
 api = "https://api.phare.io"
+phare_url = "https://app.phare.io"
 
 
 def _headers() -> dict:

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -3,7 +3,7 @@ import requests
 from datetime import datetime, timezone
 from incidentbot.configuration.settings import settings
 
-phare_url = "https://phare.io"
+phare_url = "https://app.phare.io"
 from incidentbot.logging import logger
 from incidentbot.models.database import engine, PhareIncidentRecord
 from incidentbot.models.incident import IncidentDatabaseInterface

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -139,8 +139,7 @@ class PhareIncidentUpdate:
     @staticmethod
     def update_impact(channel_id: str, impact: str):
         """
-        Change the impact level of a Phare incident via POST /uptime/incidents/{id}.
-        The endpoint requires a full replace — fetch current values first.
+        Change the impact level of a Phare incident via partial update.
         """
 
         incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
@@ -153,24 +152,10 @@ class PhareIncidentUpdate:
             ).one()
 
             try:
-                current = requests.get(
-                    f"{api}/uptime/incidents/{record.upstream_id}",
-                    headers=_headers(),
-                )
-                current.raise_for_status()
-                current_data = current.json()
-
                 resp = requests.post(
                     f"{api}/uptime/incidents/{record.upstream_id}",
                     headers=_headers(),
-                    json={
-                        "title": current_data.get("title"),
-                        "description": current_data.get("description"),
-                        "monitors": current_data.get("monitors", []),
-                        "exclude_from_downtime": current_data.get("exclude_from_downtime", False),
-                        "incident_at": current_data.get("incident_at"),
-                        "impact": impact,
-                    },
+                    json={"impact": impact},
                 )
                 resp.raise_for_status()
             except Exception as error:

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -2,6 +2,8 @@ import requests
 
 from datetime import datetime, timezone
 from incidentbot.configuration.settings import settings
+
+phare_url = "https://phare.io"
 from incidentbot.logging import logger
 from incidentbot.models.database import engine, PhareIncidentRecord
 from incidentbot.models.incident import IncidentDatabaseInterface
@@ -301,7 +303,7 @@ class PhareIncidentUpdate:
                         "text": "Open Phare",
                     },
                     "action_id": "phare.open",
-                    "url": settings.integrations.phare.url,
+                    "url": phare_url,
                 }
             )
 

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -62,7 +62,8 @@ class PhareIncident:
             "title": self.request_data["title"],
             "description": self.request_data.get("description", ""),
             "impact": self.request_data.get("impact", "operational"),
-            "monitor_ids": self.request_data.get("monitor_ids", []),
+            "monitors": self.request_data.get("monitors", []),
+            "exclude_from_downtime": self.request_data.get("exclude_from_downtime", False),
         }
 
     def start(self) -> str | None:
@@ -91,6 +92,12 @@ class PhareIncident:
             resp.raise_for_status()
             self.info = resp.json()
             logger.info(f"Created Phare incident: {self.info.get('title')}")
+
+            requests.post(
+                f"{api}/uptime/incidents/{self.info['id']}/updates",
+                headers=_headers(),
+                json={"state": "investigating", "content": "Incident is being investigated."},
+            ).raise_for_status()
 
             incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
         except Exception as error:
@@ -128,6 +135,51 @@ class PhareIncidentUpdate:
     """
     Updates a Phare incident
     """
+
+    @staticmethod
+    def update_impact(channel_id: str, impact: str):
+        """
+        Change the impact level of a Phare incident via POST /uptime/incidents/{id}.
+        The endpoint requires a full replace — fetch current values first.
+        """
+
+        incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+
+        with Session(engine) as session:
+            record = session.exec(
+                select(PhareIncidentRecord).filter(
+                    PhareIncidentRecord.parent == incident_data.id
+                )
+            ).one()
+
+            try:
+                current = requests.get(
+                    f"{api}/uptime/incidents/{record.upstream_id}",
+                    headers=_headers(),
+                )
+                current.raise_for_status()
+                current_data = current.json()
+
+                resp = requests.post(
+                    f"{api}/uptime/incidents/{record.upstream_id}",
+                    headers=_headers(),
+                    json={
+                        "title": current_data.get("title"),
+                        "description": current_data.get("description"),
+                        "monitors": current_data.get("monitors", []),
+                        "exclude_from_downtime": current_data.get("exclude_from_downtime", False),
+                        "incident_at": current_data.get("incident_at"),
+                        "impact": impact,
+                    },
+                )
+                resp.raise_for_status()
+            except Exception as error:
+                logger.error(f"Error updating Phare incident impact: {error}")
+                return
+
+            record.updated_at = datetime.now(tz=timezone.utc)
+            session.add(record)
+            session.commit()
 
     @staticmethod
     def update(channel_id: str, content: str, state: str):
@@ -183,7 +235,7 @@ class PhareIncidentUpdate:
                     ts=record.message_ts,
                     text=f"Phare Uptime incident updated to {state}.",
                     blocks=PhareIncidentUpdate.update_management_message(
-                        incident_data.channel_id
+                        incident_data.channel_id or channel_id
                     ),
                 )
             except Exception as error:

--- a/incidentbot/phare/handler.py
+++ b/incidentbot/phare/handler.py
@@ -157,7 +157,6 @@ class PhareIncidentUpdate:
                         json={"state": state, "content": content},
                     )
                     resp.raise_for_status()
-                    update_data = resp.json()
                     updates = list(record.updates or [])
                     updates.append(
                         {

--- a/incidentbot/phare/slack.py
+++ b/incidentbot/phare/slack.py
@@ -1,6 +1,3 @@
-phare_url = "https://app.phare.io"
-
-
 def return_new_phare_incident_message(channel_id: str) -> dict:
     """
     Renders content for the Phare prompt message
@@ -44,7 +41,7 @@ def return_new_phare_incident_message(channel_id: str) -> dict:
                             "type": "plain_text",
                             "text": "Open Phare",
                         },
-                        "url": phare_url,
+                        "url": "https://app.phare.io",
                     },
                 ],
             },

--- a/incidentbot/phare/slack.py
+++ b/incidentbot/phare/slack.py
@@ -1,0 +1,53 @@
+from incidentbot.configuration.settings import settings
+
+
+def return_new_phare_incident_message(channel_id: str) -> dict:
+    """
+    Renders content for the Phare prompt message
+
+    Parameters:
+        channel_id (str): the ID of the channel to post the message to
+    """
+
+    return {
+        "channel": channel_id,
+        "blocks": [
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Phare* - To start a Phare incident, use the prompt here. "
+                    + "In order to use this feature, you'll need to have access rights.",
+                },
+            },
+            {
+                "type": "actions",
+                "block_id": "phare_starter_button",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Start Phare Incident",
+                            "emoji": True,
+                        },
+                        "value": channel_id,
+                        "action_id": "phare_incident_modal",
+                        "style": "primary",
+                    },
+                    {
+                        "type": "button",
+                        "style": "primary",
+                        "action_id": "phare.open",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Open Phare",
+                        },
+                        "url": settings.integrations.phare.url,
+                    },
+                ],
+            },
+            {"type": "divider"},
+        ],
+    }

--- a/incidentbot/phare/slack.py
+++ b/incidentbot/phare/slack.py
@@ -14,7 +14,7 @@ def return_new_phare_incident_message(channel_id: str) -> dict:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Phare* - To start a Phare incident, use the prompt here. "
+                    "text": "*Phare Uptime* - To start a Phare Uptime incident, use the prompt here. "
                     + "In order to use this feature, you'll need to have access rights.",
                 },
             },
@@ -26,7 +26,7 @@ def return_new_phare_incident_message(channel_id: str) -> dict:
                         "type": "button",
                         "text": {
                             "type": "plain_text",
-                            "text": "Start Phare Incident",
+                            "text": "Start Phare Uptime Incident",
                             "emoji": True,
                         },
                         "value": channel_id,
@@ -39,7 +39,7 @@ def return_new_phare_incident_message(channel_id: str) -> dict:
                         "action_id": "phare.open",
                         "text": {
                             "type": "plain_text",
-                            "text": "Open Phare",
+                            "text": "Open Phare Uptime",
                         },
                         "url": "https://app.phare.io",
                     },

--- a/incidentbot/phare/slack.py
+++ b/incidentbot/phare/slack.py
@@ -1,4 +1,4 @@
-from incidentbot.configuration.settings import settings
+phare_url = "https://phare.io"
 
 
 def return_new_phare_incident_message(channel_id: str) -> dict:
@@ -44,7 +44,7 @@ def return_new_phare_incident_message(channel_id: str) -> dict:
                             "type": "plain_text",
                             "text": "Open Phare",
                         },
-                        "url": settings.integrations.phare.url,
+                        "url": phare_url,
                     },
                 ],
             },

--- a/incidentbot/phare/slack.py
+++ b/incidentbot/phare/slack.py
@@ -1,4 +1,4 @@
-phare_url = "https://phare.io"
+phare_url = "https://app.phare.io"
 
 
 def return_new_phare_incident_message(channel_id: str) -> dict:

--- a/incidentbot/slack/handler.py
+++ b/incidentbot/slack/handler.py
@@ -882,6 +882,36 @@ def handle_static_action(ack, body):  # noqa: F811
     ack()
 
 
+@app.action("phare.impact_select")
+def handle_static_action(ack, body):  # noqa: F811
+    logger.debug(body)
+    ack()
+
+
+@app.action("phare.monitors_select")
+def handle_static_action(ack, body):  # noqa: F811
+    logger.debug(body)
+    ack()
+
+
+@app.action("phare.open")
+def handle_static_action(ack, body):  # noqa: F811
+    logger.debug(body)
+    ack()
+
+
+@app.action("phare.update_status")
+def handle_static_action(ack, body):  # noqa: F811
+    logger.debug(body)
+    ack()
+
+
+@app.action("phare.view_incident")
+def handle_static_action(ack, body):  # noqa: F811
+    logger.debug(body)
+    ack()
+
+
 @app.action("statuspage.open")
 def handle_static_action(ack, body):  # noqa: F811
     logger.debug(body)

--- a/incidentbot/slack/messages.py
+++ b/incidentbot/slack/messages.py
@@ -1625,6 +1625,87 @@ class BlockBuilder:
         return blocks
 
     @staticmethod
+    def phare_incident_list(
+        incidents: list[dict],
+    ) -> list[dict[str, Any]]:
+        """
+        Return a message containing details on Phare incidents
+
+        Parameters:
+            incidents (list[dict]): Incidents to iterate over
+        """
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": ":fire: Phare Incidents",
+                },
+            },
+            {"type": "divider"},
+        ]
+        formatted_incidents = []
+        none_found_block = [
+            {"type": "divider"},
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": ":fire: No Phare Incidents",
+                },
+            },
+            {"type": "divider"},
+        ]
+
+        if len(incidents) == 0:
+            return none_found_block
+
+        for inc in incidents:
+            name = inc.get("name")
+            state = inc.get("state")
+            url = inc.get("url")
+            updated_at = inc.get("updated_at")
+
+            if state != "resolved":
+                entry = {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": f"*Name:* {name}"},
+                        {"type": "mrkdwn", "text": f"*State:* {state}"},
+                        {"type": "mrkdwn", "text": f"*Last Updated:* {updated_at}"},
+                    ],
+                }
+                formatted_incidents.append(entry)
+
+                if url:
+                    formatted_incidents.append(
+                        {
+                            "type": "actions",
+                            "elements": [
+                                {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Open In Phare",
+                                    },
+                                    "url": url,
+                                },
+                            ],
+                        }
+                    )
+
+                formatted_incidents.append({"type": "divider"})
+
+        if len(formatted_incidents) == 0:
+            return none_found_block
+
+        for inc in formatted_incidents:
+            blocks.append(inc)
+
+        return blocks
+
+    @staticmethod
     def task_list(
         tasks: list[Job],
     ) -> list[dict[str, Any]]:

--- a/incidentbot/slack/modals.py
+++ b/incidentbot/slack/modals.py
@@ -27,6 +27,11 @@ from incidentbot.models.maintenance_window import (
 from incidentbot.slack.client import check_user_in_group, get_digest_channel_id
 from incidentbot.slack.handler import app
 from incidentbot.slack.messages import BlockBuilder, IncidentUpdate
+from incidentbot.phare.handler import (
+    PhareIncident,
+    PhareIncidentUpdate,
+    PhareMonitors,
+)
 from incidentbot.statuspage.handler import (
     StatuspageComponents,
     StatuspageIncident,
@@ -1667,6 +1672,362 @@ def handle_submission(ack, body):  # noqa: F811
         )
     except Exception as error:
         logger.error(f"Error updating Statuspage incident: {error}")
+
+
+"""
+Phare
+"""
+
+
+@app.action("phare_incident_modal")
+def show_modal(ack, body, client):  # noqa: F811
+    """
+    Provides the modal that will display when the shortcut is
+    used to start a Phare incident
+    """
+
+    user = body.get("user").get("id")
+    channel_id = body.get("actions")[0].get("value").split("_")[-1:][0]
+    incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+
+    try:
+        phare_monitors = PhareMonitors()
+        monitor_options = [
+            {
+                "text": {
+                    "type": "plain_text",
+                    "text": name,
+                    "emoji": True,
+                },
+                "value": str(monitor_id),
+            }
+            for entry in phare_monitors.list_of_dict_name_ids
+            for name, monitor_id in entry.items()
+        ]
+    except Exception as error:
+        logger.error(f"Error fetching Phare monitors: {error}")
+        monitor_options = []
+
+    blocks = [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "block_id": incident_data.slug,
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Incident: {incident_data.slug.upper()}",
+            },
+        },
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "This Phare incident will start in *investigating* mode. "
+                + "You may change its state as the incident proceeds.",
+            },
+        },
+        {"type": "divider"},
+        {
+            "type": "input",
+            "block_id": "phare_title_input",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "phare.title_input",
+                "min_length": 1,
+            },
+            "label": {
+                "type": "plain_text",
+                "text": "Title for the incident",
+                "emoji": True,
+            },
+        },
+        {
+            "type": "input",
+            "block_id": "phare_description_input",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "phare.description_input",
+                "min_length": 1,
+            },
+            "label": {
+                "type": "plain_text",
+                "text": "Description of the incident",
+                "emoji": True,
+            },
+        },
+        {
+            "block_id": "phare_impact_select",
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Impact:*"},
+            "accessory": {
+                "type": "static_select",
+                "action_id": "phare.impact_select",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select an impact...",
+                    "emoji": True,
+                },
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Operational", "emoji": True},
+                        "value": "operational",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Degraded Performance", "emoji": True},
+                        "value": "degraded_performance",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Partial Outage", "emoji": True},
+                        "value": "partial_outage",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Major Outage", "emoji": True},
+                        "value": "major_outage",
+                    },
+                ],
+            },
+        },
+    ]
+
+    if monitor_options:
+        blocks.append(
+            {
+                "type": "section",
+                "block_id": "phare_monitors_select",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Select impacted monitors",
+                },
+                "accessory": {
+                    "action_id": "phare.monitors_select",
+                    "type": "multi_static_select",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Select monitors",
+                    },
+                    "options": monitor_options,
+                },
+            }
+        )
+
+    ack()
+
+    phare_permissions = settings.integrations.phare.permissions
+
+    if phare_permissions and phare_permissions.groups:
+        for group in phare_permissions.groups:
+            if check_user_in_group(user_id=user, group_name=group):
+                client.views_open(
+                    trigger_id=body["trigger_id"],
+                    view={
+                        "type": "modal",
+                        "callback_id": "phare_incident_modal",
+                        "title": {"type": "plain_text", "text": "Phare Incident"},
+                        "submit": {"type": "plain_text", "text": "Start"},
+                        "blocks": blocks,
+                    },
+                )
+            else:
+                client.chat_postEphemeral(
+                    channel=channel_id,
+                    user=user,
+                    text="You don't have permissions to manage Phare incidents.",
+                )
+    else:
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "phare_incident_modal",
+                "title": {"type": "plain_text", "text": "Phare Incident"},
+                "submit": {"type": "plain_text", "text": "Start"},
+                "blocks": blocks,
+            },
+        )
+
+
+@app.view("phare_incident_modal")
+def handle_submission(ack, body, client, view):  # noqa: F811
+    """
+    Handles phare_incident_modal submission
+    """
+
+    ack()
+    slug = view["blocks"][1].get("block_id")
+    incident_data = IncidentDatabaseInterface.get_one(slug=slug)
+
+    parsed = parse_modal_values(body)
+
+    title = parsed.get("phare.title_input")
+    description = parsed.get("phare.description_input")
+    impact = parsed.get("phare.impact_select")
+    selected_monitors_raw = parsed.get("phare.monitors_select") or []
+    monitor_ids = [int(m) for m in selected_monitors_raw] if selected_monitors_raw else []
+
+    incident = PhareIncident(
+        request_data={
+            "channel_id": incident_data.channel_id,
+            "title": title,
+            "description": description,
+            "impact": impact,
+            "monitor_ids": monitor_ids,
+        }
+    )
+
+    message_ts = incident.start()
+
+    if message_ts:
+        client.chat_update(
+            channel=incident_data.channel_id,
+            ts=message_ts,
+            text="Phare incident has been created.",
+            blocks=PhareIncidentUpdate.update_management_message(
+                incident_data.channel_id
+            ),
+        )
+
+
+@app.action("phare_incident_update_modal")
+def show_modal(ack, body, client):  # noqa: F811
+    """
+    Provides the modal that will display when the shortcut is used to update a Phare incident
+    """
+
+    user = body.get("user").get("id")
+    channel_id = body.get("channel").get("id")
+    incident_data = IncidentDatabaseInterface.get_one(channel_id=channel_id)
+
+    record = IncidentDatabaseInterface.get_phare_incident_record(id=incident_data.id)
+
+    blocks = [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Name*: {}\n*State*: {}\nLast Updated: {}\n".format(
+                    record.name,
+                    record.state,
+                    record.updated_at,
+                ),
+            },
+        },
+        {"type": "divider"},
+        {
+            "type": "input",
+            "block_id": f"phare_update_content_input_{channel_id}",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "phare.update_content_input",
+                "min_length": 1,
+            },
+            "label": {
+                "type": "plain_text",
+                "text": "Message to include with this update",
+                "emoji": True,
+            },
+        },
+        {
+            "block_id": "phare_incident_state_management",
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Update State:*"},
+            "accessory": {
+                "type": "static_select",
+                "action_id": "phare.update_status",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Investigating",
+                    "emoji": True,
+                },
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Investigating", "emoji": True},
+                        "value": "investigating",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Identified", "emoji": True},
+                        "value": "identified",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Monitoring", "emoji": True},
+                        "value": "monitoring",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Resolved", "emoji": True},
+                        "value": "resolved",
+                    },
+                ],
+            },
+        },
+    ]
+
+    ack()
+
+    phare_permissions = settings.integrations.phare.permissions
+
+    if phare_permissions and phare_permissions.groups:
+        for group in phare_permissions.groups:
+            if check_user_in_group(user_id=user, group_name=group):
+                client.views_open(
+                    trigger_id=body["trigger_id"],
+                    view={
+                        "type": "modal",
+                        "callback_id": "phare_incident_update_modal",
+                        "title": {"type": "plain_text", "text": "Update Incident"},
+                        "submit": {"type": "plain_text", "text": "Update"},
+                        "blocks": blocks,
+                    },
+                )
+            else:
+                client.chat_postEphemeral(
+                    channel=channel_id,
+                    user=user,
+                    text="You don't have permissions to manage Phare incidents.",
+                )
+    else:
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "phare_incident_update_modal",
+                "title": {"type": "plain_text", "text": "Update Incident"},
+                "submit": {"type": "plain_text", "text": "Update"},
+                "blocks": blocks,
+            },
+        )
+
+
+@app.view("phare_incident_update_modal")
+def handle_submission(ack, body):  # noqa: F811
+    """
+    Handles phare_incident_update_modal
+    """
+
+    ack()
+
+    channel_id = (
+        body.get("view").get("blocks")[3].get("block_id").split("_")[-1:][0]
+    )
+    values = body.get("view").get("state").get("values")
+    content = (
+        values.get(f"phare_update_content_input_{channel_id}")
+        .get("phare.update_content_input")
+        .get("value")
+    )
+    state = (
+        values.get("phare_incident_state_management")
+        .get("phare.update_status")
+        .get("selected_option")
+        .get("value")
+    )
+
+    try:
+        PhareIncidentUpdate.update(
+            channel_id=channel_id, content=content, state=state
+        )
+    except Exception as error:
+        logger.error(f"Error updating Phare incident: {error}")
 
 
 """

--- a/incidentbot/slack/modals.py
+++ b/incidentbot/slack/modals.py
@@ -1811,6 +1811,25 @@ def show_modal(ack, body, client):  # noqa: F811
             }
         )
 
+    blocks.append(
+        {
+            "type": "input",
+            "block_id": "phare_exclude_from_downtime",
+            "optional": True,
+            "element": {
+                "type": "checkboxes",
+                "action_id": "phare.exclude_from_downtime",
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Exclude from downtime calculations"},
+                        "value": "exclude",
+                    }
+                ],
+            },
+            "label": {"type": "plain_text", "text": "Downtime", "emoji": True},
+        }
+    )
+
     ack()
 
     phare_permissions = settings.integrations.phare.permissions
@@ -1863,7 +1882,8 @@ def handle_submission(ack, body, client, view):  # noqa: F811
     description = parsed.get("phare.description_input")
     impact = parsed.get("phare.impact_select")
     selected_monitors_raw = parsed.get("phare.monitors_select") or []
-    monitor_ids = [int(m) for m in selected_monitors_raw] if selected_monitors_raw else []
+    monitors = [int(m) for m in selected_monitors_raw] if selected_monitors_raw else []
+    exclude_from_downtime = "exclude" in (parsed.get("phare.exclude_from_downtime") or [])
 
     incident = PhareIncident(
         request_data={
@@ -1871,7 +1891,8 @@ def handle_submission(ack, body, client, view):  # noqa: F811
             "title": title,
             "description": description,
             "impact": impact,
-            "monitor_ids": monitor_ids,
+            "monitors": monitors,
+            "exclude_from_downtime": exclude_from_downtime,
         }
     )
 
@@ -1960,6 +1981,46 @@ def show_modal(ack, body, client):  # noqa: F811
                 ],
             },
         },
+        {
+            "block_id": "phare_incident_impact_management",
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Update Impact:*"},
+            "accessory": {
+                "type": "static_select",
+                "action_id": "phare.update_impact",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Leave unchanged",
+                    "emoji": True,
+                },
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Operational", "emoji": True},
+                        "value": "operational",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Degraded Performance", "emoji": True},
+                        "value": "degraded_performance",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Partial Outage", "emoji": True},
+                        "value": "partial_outage",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Major Outage", "emoji": True},
+                        "value": "major_outage",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Maintenance", "emoji": True},
+                        "value": "maintenance",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Unknown", "emoji": True},
+                        "value": "unknown",
+                    },
+                ],
+            },
+        },
     ]
 
     ack()
@@ -2021,6 +2082,12 @@ def handle_submission(ack, body):  # noqa: F811
         .get("selected_option")
         .get("value")
     )
+    impact_option = (
+        values.get("phare_incident_impact_management", {})
+        .get("phare.update_impact", {})
+        .get("selected_option")
+    )
+    impact = impact_option.get("value") if impact_option else None
 
     try:
         PhareIncidentUpdate.update(
@@ -2028,6 +2095,12 @@ def handle_submission(ack, body):  # noqa: F811
         )
     except Exception as error:
         logger.error(f"Error updating Phare incident: {error}")
+
+    if impact:
+        try:
+            PhareIncidentUpdate.update_impact(channel_id=channel_id, impact=impact)
+        except Exception as error:
+            logger.error(f"Error updating Phare incident impact: {error}")
 
 
 """

--- a/incidentbot/slack/modals.py
+++ b/incidentbot/slack/modals.py
@@ -1675,7 +1675,7 @@ def handle_submission(ack, body):  # noqa: F811
 
 
 """
-Phare
+Phare Uptime
 """
 
 
@@ -1723,7 +1723,7 @@ def show_modal(ack, body, client):  # noqa: F811
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "This Phare incident will start in *investigating* mode. "
+                "text": "This Phare Uptime incident will start in *investigating* mode. "
                 + "You may change its state as the incident proceeds.",
             },
         },
@@ -1823,7 +1823,7 @@ def show_modal(ack, body, client):  # noqa: F811
                     view={
                         "type": "modal",
                         "callback_id": "phare_incident_modal",
-                        "title": {"type": "plain_text", "text": "Phare Incident"},
+                        "title": {"type": "plain_text", "text": "Phare Uptime Incident"},
                         "submit": {"type": "plain_text", "text": "Start"},
                         "blocks": blocks,
                     },
@@ -1832,7 +1832,7 @@ def show_modal(ack, body, client):  # noqa: F811
                 client.chat_postEphemeral(
                     channel=channel_id,
                     user=user,
-                    text="You don't have permissions to manage Phare incidents.",
+                    text="You don't have permissions to manage Phare Uptime incidents.",
                 )
     else:
         client.views_open(
@@ -1881,7 +1881,7 @@ def handle_submission(ack, body, client, view):  # noqa: F811
         client.chat_update(
             channel=incident_data.channel_id,
             ts=message_ts,
-            text="Phare incident has been created.",
+            text="Phare Uptime incident has been created.",
             blocks=PhareIncidentUpdate.update_management_message(
                 incident_data.channel_id
             ),
@@ -1983,7 +1983,7 @@ def show_modal(ack, body, client):  # noqa: F811
                 client.chat_postEphemeral(
                     channel=channel_id,
                     user=user,
-                    text="You don't have permissions to manage Phare incidents.",
+                    text="You don't have permissions to manage Phare Uptime incidents.",
                 )
     else:
         client.views_open(

--- a/incidentbot/slack/util.py
+++ b/incidentbot/slack/util.py
@@ -103,5 +103,10 @@ def parse_modal_values(
                     result[title] = content.get("selected_time")
                 case "users_select":
                     result[title] = content.get("selected_user")
+                case "checkboxes":
+                    result[title] = [
+                        obj.get("value")
+                        for obj in content.get("selected_options", [])
+                    ]
 
     return result

--- a/tests/test_phare_handler.py
+++ b/tests/test_phare_handler.py
@@ -143,7 +143,7 @@ class TestPhareIncident(unittest.TestCase):
                 {"text": "Phare prompt has been posted to an incident.", "ts": "111.222"},
             ]
         }
-        inc = _setup_incident(mock_get_one)
+        _setup_incident(mock_get_one)
         ctx = _setup_session(mock_session, MagicMock())
 
         incident = self._make()

--- a/tests/test_phare_handler.py
+++ b/tests/test_phare_handler.py
@@ -245,24 +245,10 @@ class TestPhareIncidentUpdateUpdate(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestPhareIncidentUpdateImpact(unittest.TestCase):
-    CURRENT_INCIDENT = {
-        "id": 99,
-        "title": "DB outage",
-        "description": "Primary DB is down",
-        "monitors": [42],
-        "exclude_from_downtime": False,
-        "incident_at": "2026-03-10T08:00:00Z",
-        "state": "investigating",
-    }
-
     @patch("incidentbot.phare.handler.Session")
     @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
     @patch("incidentbot.phare.handler.requests.post")
-    @patch("incidentbot.phare.handler.requests.get")
-    def test_fetches_current_then_posts_with_incident_at_preserved(
-        self, mock_get, mock_post, mock_get_one, mock_session
-    ):
-        mock_get.return_value = _resp(self.CURRENT_INCIDENT)
+    def test_posts_partial_update(self, mock_post, mock_get_one, mock_session):
         mock_post.return_value = _resp({})
         record = _make_record()
         _setup_incident(mock_get_one)
@@ -270,29 +256,17 @@ class TestPhareIncidentUpdateImpact(unittest.TestCase):
 
         PhareIncidentUpdate.update_impact("C123", "partial_outage")
 
-        mock_get.assert_called_once_with(
-            "https://api.phare.io/uptime/incidents/99",
-            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
-        )
         mock_post.assert_called_once_with(
             "https://api.phare.io/uptime/incidents/99",
             headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
-            json={
-                "title": "DB outage",
-                "description": "Primary DB is down",
-                "monitors": [42],
-                "exclude_from_downtime": False,
-                "incident_at": "2026-03-10T08:00:00Z",
-                "impact": "partial_outage",
-            },
+            json={"impact": "partial_outage"},
         )
 
     @patch("incidentbot.phare.handler.Session")
     @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
     @patch("incidentbot.phare.handler.requests.post")
-    @patch("incidentbot.phare.handler.requests.get")
-    def test_api_error_does_not_raise(self, mock_get, mock_post, mock_get_one, mock_session):
-        mock_get.return_value.raise_for_status.side_effect = Exception("500")
+    def test_api_error_does_not_raise(self, mock_post, mock_get_one, mock_session):
+        mock_post.return_value.raise_for_status.side_effect = Exception("500")
         record = _make_record()
         _setup_incident(mock_get_one)
         _setup_session(mock_session, record)

--- a/tests/test_phare_handler.py
+++ b/tests/test_phare_handler.py
@@ -1,0 +1,343 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+# ---------------------------------------------------------------------------
+# Patch boot-time dependencies before any incidentbot import
+# ---------------------------------------------------------------------------
+mock_settings = MagicMock()
+mock_settings.PHARE_API_KEY = "test-api-key"
+mock_settings.PHARE_PROJECT_ID = "proj-123"
+mock_settings.DATABASE_URI = "sqlite:///:memory:"
+mock_settings.SLACK_BOT_TOKEN = "test-token"
+mock_settings.LOG_LEVEL = "INFO"
+mock_settings.LOG_TYPE = None
+mock_settings.IS_TEST_ENVIRONMENT = True
+
+with (
+    patch("incidentbot.configuration.settings.settings", mock_settings),
+    patch("sqlmodel.create_engine", return_value=MagicMock()),
+    patch("slack_sdk.WebClient", return_value=MagicMock()),
+    patch("apscheduler.schedulers.background.BackgroundScheduler"),
+):
+    from incidentbot.phare.handler import PhareMonitors, PhareIncident, PhareIncidentUpdate
+    from incidentbot.slack.util import parse_modal_values
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resp(json_data, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_data
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _make_record(upstream_id=99, state="investigating", updates=None, url=None):
+    r = MagicMock()
+    r.upstream_id = upstream_id
+    r.state = state
+    r.updates = updates if updates is not None else []
+    r.message_ts = "111.222"
+    r.url = url
+    return r
+
+
+def _setup_session(mock_session, record):
+    ctx = MagicMock()
+    ctx.exec.return_value.one.return_value = record
+    mock_session.return_value.__enter__.return_value = ctx
+    return ctx
+
+
+def _setup_incident(mock_get_one, channel_id="C123", incident_id=7, channel_name="incident-1"):
+    inc = MagicMock()
+    inc.id = incident_id
+    inc.channel_id = channel_id
+    inc.channel_name = channel_name
+    mock_get_one.return_value = inc
+    return inc
+
+
+# ---------------------------------------------------------------------------
+# PhareMonitors
+# ---------------------------------------------------------------------------
+
+class TestPhareMonitors(unittest.TestCase):
+    @patch("incidentbot.phare.handler.requests.get")
+    def test_single_page(self, mock_get):
+        mock_get.return_value = _resp({
+            "data": [{"id": 1, "name": "API"}, {"id": 2, "name": "Web"}],
+            "links": {"next": None},
+        })
+
+        pm = PhareMonitors()
+
+        mock_get.assert_called_once_with(
+            "https://api.phare.io/uptime/monitors",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+            params={"page": 1, "per_page": 100},
+        )
+        self.assertEqual(pm.list_of_names, ["API", "Web"])
+        self.assertEqual(pm.list_of_dict_name_ids, [{"API": 1}, {"Web": 2}])
+
+    @patch("incidentbot.phare.handler.requests.get")
+    def test_pagination_fetches_all_pages(self, mock_get):
+        mock_get.side_effect = [
+            _resp({
+                "data": [{"id": 1, "name": "API"}],
+                "links": {"next": "https://api.phare.io/uptime/monitors?page=2"},
+            }),
+            _resp({
+                "data": [{"id": 2, "name": "Web"}],
+                "links": {"next": None},
+            }),
+        ]
+
+        pm = PhareMonitors()
+
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(pm.list_of_names, ["API", "Web"])
+
+    @patch("incidentbot.phare.handler.requests.get")
+    def test_http_error_raises(self, mock_get):
+        mock_get.return_value.raise_for_status.side_effect = Exception("401")
+        mock_get.return_value.json.return_value = {}
+        with self.assertRaises(Exception):
+            PhareMonitors()
+
+
+# ---------------------------------------------------------------------------
+# PhareIncident
+# ---------------------------------------------------------------------------
+
+class TestPhareIncident(unittest.TestCase):
+    def _make(self, overrides=None):
+        data = {
+            "title": "DB outage",
+            "description": "Primary DB is down",
+            "impact": "major_outage",
+            "monitors": [42],
+            "exclude_from_downtime": False,
+            "channel_id": "C123",
+        }
+        if overrides:
+            data.update(overrides)
+        return PhareIncident(data)
+
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.slack_web_client")
+    @patch("incidentbot.phare.handler.requests.post")
+    def test_start_creates_incident_posts_initial_update_and_stores_record(
+        self, mock_post, mock_slack, mock_get_one, mock_session
+    ):
+        create_resp = _resp({"id": 99, "title": "DB outage", "state": "unknown", "url": None})
+        update_resp = _resp({"state": "investigating"})
+        mock_post.side_effect = [create_resp, update_resp]
+
+        mock_slack.conversations_history.return_value = {
+            "messages": [
+                {"text": "Phare prompt has been posted to an incident.", "ts": "111.222"},
+            ]
+        }
+        inc = _setup_incident(mock_get_one)
+        ctx = _setup_session(mock_session, MagicMock())
+
+        incident = self._make()
+        ts = incident.start()
+
+        # First POST creates the incident
+        self.assertEqual(mock_post.call_args_list[0], call(
+            "https://api.phare.io/uptime/incidents",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+            json={
+                "title": "DB outage",
+                "description": "Primary DB is down",
+                "impact": "major_outage",
+                "monitors": [42],
+                "exclude_from_downtime": False,
+            },
+        ))
+        # Second POST publishes initial investigating state
+        self.assertEqual(mock_post.call_args_list[1], call(
+            "https://api.phare.io/uptime/incidents/99/updates",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+            json={"state": "investigating", "content": "Incident is being investigated."},
+        ))
+        self.assertEqual(ts, "111.222")
+        ctx.add.assert_called_once()
+        ctx.commit.assert_called_once()
+
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.slack_web_client")
+    @patch("incidentbot.phare.handler.requests.post")
+    def test_start_returns_none_on_api_error(self, mock_post, mock_slack, mock_get_one, mock_session):
+        mock_post.return_value.raise_for_status.side_effect = Exception("500")
+        mock_slack.conversations_history.return_value = {"messages": []}
+
+        result = self._make().start()
+
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# PhareIncidentUpdate.update
+# ---------------------------------------------------------------------------
+
+class TestPhareIncidentUpdateUpdate(unittest.TestCase):
+    @patch("incidentbot.phare.handler.slack_web_client")
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.requests.post")
+    def test_state_update_posts_to_updates_endpoint(self, mock_post, mock_get_one, mock_session, mock_slack):
+        record = _make_record()
+        _setup_incident(mock_get_one)
+        _setup_session(mock_session, record)
+        mock_post.return_value = _resp({})
+
+        PhareIncidentUpdate.update("C123", "Root cause found", "identified")
+
+        mock_post.assert_called_once_with(
+            "https://api.phare.io/uptime/incidents/99/updates",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+            json={"state": "identified", "content": "Root cause found"},
+        )
+        self.assertEqual(len(record.updates), 1)
+        self.assertEqual(record.updates[0]["state"], "identified")
+        self.assertEqual(record.updates[0]["content"], "Root cause found")
+
+    @patch("incidentbot.phare.handler.slack_web_client")
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.requests.post")
+    def test_resolved_calls_recover_endpoint(self, mock_post, mock_get_one, mock_session, mock_slack):
+        record = _make_record()
+        _setup_incident(mock_get_one)
+        _setup_session(mock_session, record)
+        mock_post.return_value = _resp({})
+
+        PhareIncidentUpdate.update("C123", "", "resolved")
+
+        mock_post.assert_called_once_with(
+            "https://api.phare.io/uptime/incidents/99/recover",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+        )
+
+    @patch("incidentbot.phare.handler.slack_web_client")
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.requests.post")
+    def test_api_error_does_not_raise(self, mock_post, mock_get_one, mock_session, mock_slack):
+        record = _make_record()
+        _setup_incident(mock_get_one)
+        _setup_session(mock_session, record)
+        mock_post.return_value.raise_for_status.side_effect = Exception("503")
+
+        PhareIncidentUpdate.update("C123", "update", "monitoring")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# PhareIncidentUpdate.update_impact
+# ---------------------------------------------------------------------------
+
+class TestPhareIncidentUpdateImpact(unittest.TestCase):
+    CURRENT_INCIDENT = {
+        "id": 99,
+        "title": "DB outage",
+        "description": "Primary DB is down",
+        "monitors": [42],
+        "exclude_from_downtime": False,
+        "incident_at": "2026-03-10T08:00:00Z",
+        "state": "investigating",
+    }
+
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.requests.post")
+    @patch("incidentbot.phare.handler.requests.get")
+    def test_fetches_current_then_posts_with_incident_at_preserved(
+        self, mock_get, mock_post, mock_get_one, mock_session
+    ):
+        mock_get.return_value = _resp(self.CURRENT_INCIDENT)
+        mock_post.return_value = _resp({})
+        record = _make_record()
+        _setup_incident(mock_get_one)
+        _setup_session(mock_session, record)
+
+        PhareIncidentUpdate.update_impact("C123", "partial_outage")
+
+        mock_get.assert_called_once_with(
+            "https://api.phare.io/uptime/incidents/99",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+        )
+        mock_post.assert_called_once_with(
+            "https://api.phare.io/uptime/incidents/99",
+            headers={"Authorization": "Bearer test-api-key", "X-Phare-Project-Id": "proj-123"},
+            json={
+                "title": "DB outage",
+                "description": "Primary DB is down",
+                "monitors": [42],
+                "exclude_from_downtime": False,
+                "incident_at": "2026-03-10T08:00:00Z",
+                "impact": "partial_outage",
+            },
+        )
+
+    @patch("incidentbot.phare.handler.Session")
+    @patch("incidentbot.phare.handler.IncidentDatabaseInterface.get_one")
+    @patch("incidentbot.phare.handler.requests.post")
+    @patch("incidentbot.phare.handler.requests.get")
+    def test_api_error_does_not_raise(self, mock_get, mock_post, mock_get_one, mock_session):
+        mock_get.return_value.raise_for_status.side_effect = Exception("500")
+        record = _make_record()
+        _setup_incident(mock_get_one)
+        _setup_session(mock_session, record)
+
+        PhareIncidentUpdate.update_impact("C123", "major_outage")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# parse_modal_values — checkboxes case
+# ---------------------------------------------------------------------------
+
+class TestParseModalValuesCheckboxes(unittest.TestCase):
+    def _body(self, selected_values):
+        return {
+            "view": {
+                "blocks": [],
+                "state": {
+                    "values": {
+                        "phare_exclude_from_downtime": {
+                            "phare.exclude_from_downtime": {
+                                "type": "checkboxes",
+                                "selected_options": [
+                                    {"value": v} for v in selected_values
+                                ],
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+    def test_checked_returns_value(self):
+        result = parse_modal_values(self._body(["exclude"]))
+        self.assertEqual(result["phare.exclude_from_downtime"], ["exclude"])
+
+    def test_unchecked_returns_empty_list(self):
+        result = parse_modal_values(self._body([]))
+        self.assertEqual(result["phare.exclude_from_downtime"], [])
+
+    def test_exclude_from_downtime_bool_derivation(self):
+        checked = parse_modal_values(self._body(["exclude"]))
+        unchecked = parse_modal_values(self._body([]))
+        self.assertTrue("exclude" in (checked.get("phare.exclude_from_downtime") or []))
+        self.assertFalse("exclude" in (unchecked.get("phare.exclude_from_downtime") or []))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #765

Implements Phare uptime/status-page integration mirroring the existing Atlassian Statuspage integration.

- `incidentbot/phare/` module with `PhareIncident`, `PhareIncidentUpdate`, `PhareMonitors` (live paginated monitor fetch)
- `PhareIncidentRecord` DB model + Alembic migration
- `PhareIntegration` config model + `PHARE_API_KEY` / `PHARE_PROJECT_ID` env vars
- Slack create/update modals, management message, action stubs
- `GET /api/v1/incident/{slug}/phare` API route (superuser-gated)

Key differences from Statuspage: uses `state` not `status`, updates are separate POST resources, recovery is a dedicated 204 endpoint.

**Docs:** incidentbot/incidentbot.github.io#3