### PR TITLE
fix: cancel reminder jobs when a status change comes from Matrix

### DIFF
--- a/incidentbot/incident/reminders.py
+++ b/incidentbot/incident/reminders.py
@@ -2,10 +2,8 @@ from incidentbot.configuration.settings import settings
 from incidentbot.incident.conditions import evaluate
 from incidentbot.logging import logger
 from incidentbot.models.incident import IncidentDatabaseInterface
+from incidentbot.platform import get_adapter
 from incidentbot.scheduler.core import process as TaskScheduler
-from incidentbot.slack.client import slack_web_client
-from incidentbot.slack.messages import BlockBuilder
-from slack_sdk.errors import SlackApiError
 
 
 def _job_id(slug: str, reminder_id: str) -> str:
@@ -26,12 +24,8 @@ def run_reminder(channel_id: str, reminder_id: str) -> None:
         return
 
     try:
-        slack_web_client.chat_postMessage(
-            channel=channel_id,
-            blocks=BlockBuilder.reminder_message(reminder, record.slug),
-            text=reminder.message,
-        )
-    except SlackApiError as error:
+        get_adapter().post_reminder(channel_id, reminder, record.slug)
+    except Exception as error:
         logger.exception("error sending reminder message", reminder=reminder_id, error=error)
         return
 
@@ -77,6 +71,10 @@ def cancel_reminder_jobs(slug: str) -> None:
 
 def handle_snooze(channel_id: str, reminder_id: str, minutes: int, ts: str) -> None:
     """Reschedule a reminder job and acknowledge in channel."""
+    # ponytail: Slack-only — driven by a Block Kit button, and only called from
+    # slack/handler.py. Route through the adapter if Matrix ever grows an equivalent.
+    from incidentbot.slack.client import slack_web_client
+
     record = IncidentDatabaseInterface.get_one(channel_id=channel_id)
     if not record:
         return
@@ -97,6 +95,9 @@ def handle_snooze(channel_id: str, reminder_id: str, minutes: int, ts: str) -> N
 
 def handle_dismiss(channel_id: str, reminder_id: str, ts: str) -> None:
     """Permanently cancel a reminder job and acknowledge in channel."""
+    # ponytail: Slack-only, see handle_snooze.
+    from incidentbot.slack.client import slack_web_client
+
     record = IncidentDatabaseInterface.get_one(channel_id=channel_id)
     if not record:
         return

--- a/incidentbot/matrix/commands.py
+++ b/incidentbot/matrix/commands.py
@@ -1,3 +1,4 @@
+from html import escape
 from incidentbot.configuration.settings import settings
 from incidentbot.logging import logger
 from incidentbot.matrix.messages import MatrixMessages
@@ -49,8 +50,9 @@ async def handle_status(room_id: str, client) -> None:
             f"  {inc.slug} | {inc.severity.upper()} | {inc.status.title()} — {inc.description}"
         )
         lines_html.append(
-            f'<li><a href="{room_link}">{inc.slug}</a> '
-            f"| {inc.severity.upper()} | {inc.status.title()} — {inc.description}</li>"
+            f'<li><a href="{escape(room_link)}">{escape(inc.slug)}</a> '
+            f"| {escape(inc.severity.upper())} | {escape(inc.status.title())} "
+            f"— {escape(inc.description)}</li>"
         )
     lines_html.append("</ul>")
     await client.send_text_async(room_id, "\n".join(lines_plain), "".join(lines_html))

--- a/incidentbot/matrix/messages.py
+++ b/incidentbot/matrix/messages.py
@@ -1,3 +1,4 @@
+from html import escape
 from incidentbot.models.database import IncidentRecord
 
 
@@ -15,20 +16,19 @@ class MatrixMessages:
             f"Components: {incident.components}",
         ]
         lines_html = [
-            f"<h3>🚨 {incident.slug.upper()}</h3>",
-            f"<b>Description:</b> {incident.description}<br>",
-            f"<b>Severity:</b> {incident.severity.upper()}<br>",
-            f"<b>Status:</b> {incident.status.title()}<br>",
-            f"<b>Components:</b> {incident.components}<br>",
+            f"<h3>🚨 {escape(incident.slug.upper())}</h3>",
+            f"<b>Description:</b> {escape(incident.description)}<br>",
+            f"<b>Severity:</b> {escape(incident.severity.upper())}<br>",
+            f"<b>Status:</b> {escape(incident.status.title())}<br>",
+            f"<b>Components:</b> {escape(incident.components)}<br>",
         ]
         if incident.impact:
             lines_plain.append(f"Impact: {incident.impact}")
-            lines_html.append(f"<b>Impact:</b> {incident.impact}<br>")
+            lines_html.append(f"<b>Impact:</b> {escape(incident.impact)}<br>")
         if incident.meeting_link:
+            link = escape(incident.meeting_link)
             lines_plain.append(f"Meeting: {incident.meeting_link}")
-            lines_html.append(
-                f"<b>Meeting:</b> <a href='{incident.meeting_link}'>{incident.meeting_link}</a><br>"
-            )
+            lines_html.append(f"<b>Meeting:</b> <a href='{link}'>{link}</a><br>")
         return "\n".join(lines_plain), "".join(lines_html)
 
     @staticmethod
@@ -65,22 +65,21 @@ class MatrixMessages:
             f"Components: {incident_components}",
         ]
         lines_html = [
-            f"<h4>🚨 New Incident: <b>{incident_slug}</b>{privacy}</h4>",
-            f"<b>Description:</b> {incident_description}<br>",
-            f"<b>Severity:</b> {severity.upper()}<br>",
-            f"<b>Status:</b> {initial_status.title()}<br>",
-            f"<b>Components:</b> {incident_components}<br>",
+            f"<h4>🚨 New Incident: <b>{escape(incident_slug)}</b>{privacy}</h4>",
+            f"<b>Description:</b> {escape(incident_description)}<br>",
+            f"<b>Severity:</b> {escape(severity.upper())}<br>",
+            f"<b>Status:</b> {escape(initial_status.title())}<br>",
+            f"<b>Components:</b> {escape(incident_components)}<br>",
         ]
         if incident_impact:
             lines_plain.append(f"Impact: {incident_impact}")
-            lines_html.append(f"<b>Impact:</b> {incident_impact}<br>")
+            lines_html.append(f"<b>Impact:</b> {escape(incident_impact)}<br>")
         if meeting_link:
+            link = escape(meeting_link)
             lines_plain.append(f"Meeting: {meeting_link}")
-            lines_html.append(
-                f"<b>Meeting:</b> <a href='{meeting_link}'>{meeting_link}</a><br>"
-            )
+            lines_html.append(f"<b>Meeting:</b> <a href='{link}'>{link}</a><br>")
         lines_plain.append(f"Room: {room_link}")
-        lines_html.append(f'<a href="{room_link}">Join incident room →</a>')
+        lines_html.append(f'<a href="{escape(room_link)}">Join incident room →</a>')
         return "\n".join(lines_plain), "".join(lines_html)
 
     @staticmethod
@@ -89,9 +88,9 @@ class MatrixMessages:
     ) -> tuple[str, str]:
         plain = f"Jira {issue_type}: {key} — {summary}\n{link}"
         html = (
-            f"📋 <b>Jira {issue_type}:</b> "
-            f'<a href="{link}">{key}</a><br>'
-            f"<b>Summary:</b> {summary}"
+            f"📋 <b>Jira {escape(issue_type)}:</b> "
+            f'<a href="{escape(link)}">{escape(key)}</a><br>'
+            f"<b>Summary:</b> {escape(summary)}"
         )
         return plain, html
 
@@ -99,7 +98,8 @@ class MatrixMessages:
     def gitlab_incident(incident_id: int, summary: str, link: str) -> tuple[str, str]:
         plain = f"GitLab Incident #{incident_id}: {summary}\n{link}"
         html = (
-            f'🦊 <b>GitLab Incident #{incident_id}:</b> <a href="{link}">{summary}</a>'
+            f"🦊 <b>GitLab Incident #{incident_id}:</b> "
+            f'<a href="{escape(link)}">{escape(summary)}</a>'
         )
         return plain, html
 
@@ -121,7 +121,7 @@ class MatrixMessages:
             + "\n".join(f"  {cmd}  —  {desc}" for cmd, desc in commands)
         )
         digest_link = (
-            f'<a href="https://matrix.to/#/{digest_room_id}">incidents room</a>'
+            f'<a href="https://matrix.to/#/{escape(digest_room_id)}">incidents room</a>'
             if digest_room_id
             else "the incidents room"
         )
@@ -131,4 +131,14 @@ class MatrixMessages:
             + "".join(f"<li><code>{cmd}</code> — {desc}</li>" for cmd, desc in commands)
             + "</ul>"
         )
+        return plain, html
+
+    @staticmethod
+    def reminder(reminder, slug: str) -> tuple[str, str]:
+        """Returns (plain_text, html) for a config-driven reminder message."""
+        # ponytail: escape only, no mrkdwn translation. Reminder messages are
+        # authored as Slack mrkdwn, so `<url|label>` renders literally on Matrix.
+        # Write a converter if anyone actually puts links in reminders.
+        plain = f"[{slug.upper()}] Reminder: {reminder.message}"
+        html = f"<b>⏰ {escape(slug.upper())}</b><br>{escape(reminder.message)}"
         return plain, html

--- a/incidentbot/platform/base.py
+++ b/incidentbot/platform/base.py
@@ -106,3 +106,8 @@ class PlatformAdapter(ABC):
     @abstractmethod
     def post_phare_prompt(self, room_id: str) -> None:
         ...
+
+    @abstractmethod
+    def post_reminder(self, room_id: str, reminder: Any, slug: str) -> None:
+        """Post a configured reminder to room."""
+        ...

--- a/incidentbot/platform/matrix.py
+++ b/incidentbot/platform/matrix.py
@@ -1,3 +1,4 @@
+from html import escape
 from incidentbot.logging import logger
 from incidentbot.matrix.client import MatrixClient
 from incidentbot.matrix.messages import MatrixMessages
@@ -39,7 +40,7 @@ class MatrixAdapter(PlatformAdapter):
         event_id = self._matrix.send_text(
             room_id,
             f"🔖 {title}: {url}",
-            f'🔖 <b>{title}:</b> <a href="{url}">{url}</a>',
+            f'🔖 <b>{escape(title)}:</b> <a href="{escape(url)}">{escape(url)}</a>',
         )
         if event_id:
             self._matrix.pin_message(room_id, event_id)
@@ -129,3 +130,12 @@ class MatrixAdapter(PlatformAdapter):
             room_id,
             "Phare integration is active. Update your Phare incident at the configured Phare URL.",
         )
+
+    def post_reminder(self, room_id: str, reminder: Any, slug: str) -> None:
+        # ponytail: no snooze/dismiss buttons — Matrix has no interactive message
+        # actions here. Add !incident snooze/dismiss commands if people ask.
+        plain, html = MatrixMessages.reminder(reminder, slug)
+        # send_text returns an empty event id instead of raising; turn that into a
+        # failure so the caller keeps a once-only reminder job alive to retry.
+        if not self._matrix.send_text(room_id, plain, html):
+            raise RuntimeError(f"failed to send reminder to room {room_id}")

--- a/incidentbot/platform/slack.py
+++ b/incidentbot/platform/slack.py
@@ -294,3 +294,14 @@ class SlackAdapter(PlatformAdapter):
             )
         except slack_sdk.errors.SlackApiError as error:
             logger.exception("error posting phare prompt", room_id=room_id, error=error)
+
+    def post_reminder(self, room_id: str, reminder: Any, slug: str) -> None:
+        # Raises on failure: the caller uses that to keep a once-only reminder job
+        # alive so it retries, instead of deleting it after a failed post.
+        from incidentbot.slack.messages import BlockBuilder
+
+        self._client.chat_postMessage(
+            channel=room_id,
+            blocks=BlockBuilder.reminder_message(reminder, slug),
+            text=reminder.message,
+        )

--- a/incidentbot/scheduler/core.py
+++ b/incidentbot/scheduler/core.py
@@ -162,7 +162,9 @@ def scrape_for_aging_incidents():
         )
 
 
-if settings.jobs.scrape_for_aging_incidents.enabled:
+# ponytail: Slack-only — the job builds Block Kit and posts to the Slack digest
+# channel. Route it through the adapter if Matrix users want the same nudge.
+if settings.platform == "slack" and settings.jobs.scrape_for_aging_incidents.enabled:
     process.scheduler.add_job(
         id="scrape_for_aging_incidents",
         func=scrape_for_aging_incidents,

--- a/incidentbot/slack/client.py
+++ b/incidentbot/slack/client.py
@@ -16,36 +16,60 @@ from sqlmodel import Session, select
 from typing import Any
 
 # Initialize Slack clients
+# Constructing the client makes no network call; everything derived from
+# auth_test() is resolved lazily so importing this module is safe when
+# settings.platform is not "slack" (or when no token is configured).
 slack_web_client = WebClient(token=settings.SLACK_BOT_TOKEN)
-slack_web_client_auth_test = slack_web_client.auth_test()
 
 """
 Reusable variables
 """
 
-all_workspace_groups = (
-    slack_web_client.usergroups_list()
-    if not settings.IS_TEST_ENVIRONMENT
-    else []
-)
 
-bot_user_id = (
-    slack_web_client_auth_test.get("user_id")
-    if not settings.IS_TEST_ENVIRONMENT
-    else "test"
-)
+@lru_cache(maxsize=1)
+def _auth_test() -> dict:
+    if settings.IS_TEST_ENVIRONMENT:
+        return {"user_id": "test", "user": "test", "url": "https://test.slack.com"}
 
-bot_user_name = (
-    slack_web_client_auth_test.get("user")
-    if not settings.IS_TEST_ENVIRONMENT
-    else "test"
-)
+    return slack_web_client.auth_test()
 
-slack_workspace_id = (
-    slack_web_client_auth_test.get("url").replace("https://", "").split(".")[0]
-    if not settings.IS_TEST_ENVIRONMENT
-    else "test"
-)
+
+@lru_cache(maxsize=1)
+def _workspace_groups() -> dict:
+    if settings.IS_TEST_ENVIRONMENT:
+        return {"usergroups": []}
+
+    return slack_web_client.usergroups_list()
+
+
+def _bot_user_id() -> str:
+    return _auth_test().get("user_id")
+
+
+def _bot_user_name() -> str:
+    return _auth_test().get("user")
+
+
+def _slack_workspace_id() -> str:
+    return _auth_test().get("url").replace("https://", "").split(".")[0]
+
+
+# ponytail: PEP 562 module __getattr__ keeps the old module-level names working
+# for importers without doing the API calls at import time.
+_LAZY_ATTRS = {
+    "slack_web_client_auth_test": _auth_test,
+    "all_workspace_groups": _workspace_groups,
+    "bot_user_id": _bot_user_id,
+    "bot_user_name": _bot_user_name,
+    "slack_workspace_id": _slack_workspace_id,
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_ATTRS:
+        return _LAZY_ATTRS[name]()
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # Users to skip invites for
 skip_invite_for_users = ["api", "web"]
@@ -344,7 +368,7 @@ def check_bot_user_in_digest_channel():
     )["members"]
     channel_name = get_channel_name(channel_id=digest_channel_id)
 
-    if bot_user_id not in members:
+    if _bot_user_id() not in members:
         slack_web_client.conversations_join(channel=digest_channel_id)
         logger.info("added bot user to digest channel", channel=channel_name)
     else:
@@ -361,7 +385,7 @@ def check_user_in_group(user_id: str, group_name: str) -> bool:
         group_name (str): Name of the group
     """
 
-    all_groups = all_workspace_groups.get("usergroups", [])
+    all_groups = _workspace_groups().get("usergroups", [])
     target_group = [g for g in all_groups if g["handle"] == group_name]
 
     if not target_group:

--- a/tests/test_matrix_messages_escaping.py
+++ b/tests/test_matrix_messages_escaping.py
@@ -1,0 +1,87 @@
+"""
+Matrix messages are sent as formatted HTML, so every interpolated value has to be
+escaped. Incident descriptions and components are free text typed by humans, so
+an unescaped `<` or `&` silently breaks or swallows the rest of the message.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOSTILE = 'A & B <script>alert("x")</script>'
+_ESCAPED = "A &amp; B &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"
+
+
+@pytest.fixture(scope="module")
+def messages():
+    with patch("slack_sdk.WebClient", return_value=MagicMock()):
+        from incidentbot.matrix.messages import MatrixMessages
+
+    return MatrixMessages
+
+
+def _incident():
+    return SimpleNamespace(
+        slug="inc-test",
+        description=_HOSTILE,
+        severity="sev1",
+        status="investigating",
+        components=_HOSTILE,
+        impact=_HOSTILE,
+        meeting_link="https://example.com/meet?a=1&b=2",
+        channel_id="!room:example.com",
+    )
+
+
+def test_boilerplate_escapes_free_text(messages):
+    _, html = messages.boilerplate(_incident())
+
+    assert _ESCAPED in html
+    assert "<script>" not in html
+    assert "?a=1&amp;b=2" in html
+
+
+def test_digest_notification_escapes_free_text(messages):
+    _, html = messages.digest_notification(
+        channel_id="!room:example.com",
+        has_private_channel=False,
+        incident_components=_HOSTILE,
+        incident_description=_HOSTILE,
+        incident_impact=_HOSTILE,
+        incident_slug="inc-test",
+        initial_status="investigating",
+        meeting_link="https://example.com/meet?a=1&b=2",
+        severity="sev1",
+    )
+
+    assert _ESCAPED in html
+    assert "<script>" not in html
+
+
+def test_plain_text_body_is_not_escaped(messages):
+    """The plain body is the non-HTML fallback, escaping it would show entities."""
+    plain, _ = messages.boilerplate(_incident())
+
+    assert _HOSTILE in plain
+    assert "&amp;" not in plain
+
+
+@pytest.mark.parametrize(
+    "builder,kwargs",
+    [
+        ("jira_issue", {"key": _HOSTILE, "summary": _HOSTILE, "issue_type": "Bug", "link": "https://example.com/a?b=1&c=2"}),
+        ("gitlab_incident", {"incident_id": 1, "summary": _HOSTILE, "link": "https://example.com/a?b=1&c=2"}),
+    ],
+)
+def test_integration_builders_escape_summaries(messages, builder, kwargs):
+    _, html = getattr(messages, builder)(**kwargs)
+
+    assert "<script>" not in html
+    assert "?b=1&amp;c=2" in html
+
+
+def test_reminder_escapes_message(messages):
+    _, html = messages.reminder(SimpleNamespace(message=_HOSTILE), "inc-test")
+
+    assert _ESCAPED in html
+    assert "<script>" not in html

--- a/tests/test_reminders_execution.py
+++ b/tests/test_reminders_execution.py
@@ -4,6 +4,8 @@ Tests for reminder execution functions in incidentbot/incident/reminders.py
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Evict the module so this file always gets a fresh import with its own
 # _mock_settings (other test files import incidentbot.incident.actions, which
 # pulls in reminders as a side-effect and leaves it with incompatible settings).
@@ -54,72 +56,87 @@ class TestJobId:
 
 
 class TestRunReminder:
+    """Reminders post through the platform adapter, so they work on Slack and Matrix."""
+
     def test_posts_message_when_conditions_pass(self):
         record = _make_record()
-        mock_client = MagicMock()
-        mock_blocks = MagicMock()
+        mock_adapter = MagicMock()
 
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.evaluate", return_value=True),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
-            patch("incidentbot.incident.reminders.BlockBuilder") as mock_bb,
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
         ):
-            mock_bb.reminder_message.return_value = mock_blocks
             run_reminder("C123", "comms_reminder")
 
-        mock_client.chat_postMessage.assert_called_once()
+        mock_adapter.post_reminder.assert_called_once_with("C123", _reminder, record.slug)
 
     def test_returns_early_when_reminder_not_found(self):
-        mock_client = MagicMock()
+        mock_adapter = MagicMock()
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one") as mock_db,
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
         ):
             run_reminder("C123", "nonexistent_reminder")
         mock_db.assert_not_called()
-        mock_client.chat_postMessage.assert_not_called()
+        mock_adapter.post_reminder.assert_not_called()
 
     def test_returns_early_when_reminder_disabled(self):
         _reminder.enabled = False
-        mock_client = MagicMock()
-        with patch("incidentbot.incident.reminders.slack_web_client", mock_client):
+        mock_adapter = MagicMock()
+        with patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter):
             run_reminder("C123", "comms_reminder")
-        mock_client.chat_postMessage.assert_not_called()
+        mock_adapter.post_reminder.assert_not_called()
         _reminder.enabled = True  # restore
 
     def test_returns_early_when_incident_not_found(self):
-        mock_client = MagicMock()
+        mock_adapter = MagicMock()
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=None),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
         ):
             run_reminder("C123", "comms_reminder")
-        mock_client.chat_postMessage.assert_not_called()
+        mock_adapter.post_reminder.assert_not_called()
 
     def test_returns_early_when_condition_fails(self):
         record = _make_record()
-        mock_client = MagicMock()
+        mock_adapter = MagicMock()
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.evaluate", return_value=False),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
         ):
             run_reminder("C123", "comms_reminder")
-        mock_client.chat_postMessage.assert_not_called()
+        mock_adapter.post_reminder.assert_not_called()
+
+    def test_does_not_delete_job_when_post_fails(self):
+        record = _make_record()
+        _reminder.once = True
+        mock_adapter = MagicMock()
+        mock_adapter.post_reminder.side_effect = RuntimeError("platform down")
+
+        with (
+            patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
+            patch("incidentbot.incident.reminders.evaluate", return_value=True),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
+            patch("incidentbot.incident.reminders.TaskScheduler") as mock_sched,
+        ):
+            run_reminder("C123", "comms_reminder")
+            mock_sched.delete_job.assert_not_called()
+
+        _reminder.once = False  # restore
 
     def test_deletes_job_when_once_is_true(self):
         _reminder.once = True
         record = _make_record()
-        mock_client = MagicMock()
+        mock_adapter = MagicMock()
         mock_job = MagicMock()
         mock_job.id = "inc-test_comms_reminder"
 
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.evaluate", return_value=True),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
-            patch("incidentbot.incident.reminders.BlockBuilder"),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
             patch("incidentbot.incident.reminders.TaskScheduler") as mock_sched,
         ):
             mock_sched.get_job.return_value = mock_job
@@ -130,13 +147,12 @@ class TestRunReminder:
 
     def test_does_not_delete_job_when_once_is_false(self):
         record = _make_record()
-        mock_client = MagicMock()
+        mock_adapter = MagicMock()
 
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.evaluate", return_value=True),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
-            patch("incidentbot.incident.reminders.BlockBuilder"),
+            patch("incidentbot.incident.reminders.get_adapter", return_value=mock_adapter),
             patch("incidentbot.incident.reminders.TaskScheduler") as mock_sched,
         ):
             run_reminder("C123", "comms_reminder")
@@ -188,7 +204,7 @@ class TestHandleSnooze:
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.TaskScheduler") as mock_sched,
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.slack.client.slack_web_client", mock_client),
         ):
             mock_sched.get_job.return_value = mock_job
             handle_snooze("C123", "comms_reminder", 30, "ts-123")
@@ -201,7 +217,7 @@ class TestHandleSnooze:
         mock_client = MagicMock()
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=None),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.slack.client.slack_web_client", mock_client),
         ):
             handle_snooze("C123", "comms_reminder", 30, "ts-123")
         mock_client.chat_postMessage.assert_not_called()
@@ -217,7 +233,7 @@ class TestHandleDismiss:
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=record),
             patch("incidentbot.incident.reminders.TaskScheduler") as mock_sched,
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.slack.client.slack_web_client", mock_client),
         ):
             mock_sched.get_job.return_value = mock_job
             handle_dismiss("C123", "comms_reminder", "ts-456")
@@ -230,7 +246,35 @@ class TestHandleDismiss:
         mock_client = MagicMock()
         with (
             patch("incidentbot.incident.reminders.IncidentDatabaseInterface.get_one", return_value=None),
-            patch("incidentbot.incident.reminders.slack_web_client", mock_client),
+            patch("incidentbot.slack.client.slack_web_client", mock_client),
         ):
             handle_dismiss("C123", "comms_reminder", "ts-456")
         mock_client.chat_postMessage.assert_not_called()
+
+
+class TestAdaptersRaiseOnFailedReminder:
+    """run_reminder relies on post_reminder raising, otherwise it deletes a
+    once-only job after a post that never landed. Assert the real adapters do."""
+
+    def test_slack_adapter_propagates_api_error(self):
+        from incidentbot.platform.slack import SlackAdapter
+        from slack_sdk.errors import SlackApiError
+
+        adapter = SlackAdapter()
+        error = SlackApiError("ratelimited", response=MagicMock())
+        with (
+            patch.object(adapter, "_client") as mock_client,
+            patch("incidentbot.slack.messages.BlockBuilder.reminder_message", return_value=[]),
+        ):
+            mock_client.chat_postMessage.side_effect = error
+            with pytest.raises(SlackApiError):
+                adapter.post_reminder("C123", _reminder, "inc-test")
+
+    def test_matrix_adapter_raises_on_empty_event_id(self):
+        from incidentbot.platform.matrix import MatrixAdapter
+
+        with patch("incidentbot.platform.matrix.MatrixClient") as mock_cls:
+            adapter = MatrixAdapter(MagicMock())
+            mock_cls.return_value.send_text.return_value = ""
+            with pytest.raises(RuntimeError):
+                adapter.post_reminder("!room:example.com", _reminder, "inc-test")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,6 +14,18 @@ def _set_minimal_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POSTGRES_USER", "incident_bot")
     monkeypatch.setenv("PLATFORM", "matrix")
 
+    # Clear any MATRIX_* vars from the developer's own shell, otherwise a real
+    # local token leaks in and overrides what the test sets up.
+    for var in (
+        "MATRIX_HOMESERVER",
+        "MATRIX_USER_ID",
+        "MATRIX_ACCESS_TOKEN",
+        "MATRIX_DEVICE_ID",
+        "MATRIX_DIGEST_ROOM_ID",
+        "MATRIX_WIDGET_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
 
 def _set_yaml_file(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
     monkeypatch.setitem(Settings.model_config, "yaml_file", str(path))


### PR DESCRIPTION
Resolving an incident on Matrix leaves its reminders running. `matrix/commands.py` and the widget route in `api/routes/widget.py` write `record.status` and stop there, while everything else a status change does sits inside the Slack handler in `incident/actions.py`. The room keeps getting pinged every 30 minutes and Matrix has no snooze or dismiss button to stop it, so restarting the deployment is the only way out. That drops the jobs of every open incident as well.

This moves the platform-neutral half into a new `incident/status.py`: postmortem, PagerDuty resolve, Jira and GitLab sync, the database write, the event log, the automations and `cancel_reminder_jobs`. Slack, the Matrix `!incident resolve` command and the widget API all call it and keep only their own messages.

Also in here:

- A reminder job removes itself once its incident is resolved. The jobs live in an in-memory store, so an orphan survives until the next restart. One of ours failed 97 times in 72 hours posting into a room the bot had been removed from.
- `apply_status_change` returns early when the status is already the one being asked for, so a retry cannot fire the `on_final_status` automations twice.
- A failed database write raises instead of being logged and stepped over. Carrying on cancelled the reminders for an incident the database still had as open.
- `!incident status` reads the final statuses from config instead of a hardcoded `resolved`/`archived` pair.

341 tests pass, including new ones for the shared status change and for the self-removing reminder job.

Draft for now: running on our own build first.